### PR TITLE
Recent bower versions error out when the --config.cwd option has a do…

### DIFF
--- a/djangobwr/management/commands/bower_install.py
+++ b/djangobwr/management/commands/bower_install.py
@@ -182,7 +182,7 @@ class Command(BaseCommand):
         self.with_version = options.get("with_version")
         self.keep_packages = options.get("keep_packages")
 
-        temp_dir = getattr(settings, 'BWR_APP_TMP_FOLDER', '.tmp')
+        temp_dir = getattr(settings, 'BWR_APP_TMP_FOLDER', 'tmp')
         temp_dir = os.path.abspath(temp_dir)
 
         # finders


### PR DESCRIPTION
…t in it

(like .tmp) does. Renaming the temporary directory fixes this. Commit ready for
merge.
