### PR TITLE
Remove code that tried to prefer installing minified version.

### DIFF
--- a/djangobwr/management/commands/bower_install.py
+++ b/djangobwr/management/commands/bower_install.py
@@ -142,12 +142,6 @@ class Command(BaseCommand):
                         src_pattern = os.path.join(src_root, pattern)
                         # main_list elements can be fileglob patterns
                         for src_path in glob.glob(src_pattern):
-                            # See if we have a minified alternative
-                            path, ext = os.path.splitext(src_path)
-                            min_path = path+".min"+ext
-                            if os.path.exists(min_path):
-                                src_path = min_path
-
                             if not os.path.exists(src_path):
                                 print("Could not find source path: %s" % (src_path, ))
 


### PR DESCRIPTION
This breaks things such as jquery-migrate, where you want to install the
non-minified version for development, and the minified one for production.
The correct way to do this is with "overrides" in bower.json.
